### PR TITLE
Added generate report summary

### DIFF
--- a/generate_report_summary.py
+++ b/generate_report_summary.py
@@ -1,0 +1,62 @@
+import json
+import argparse
+from argparse import RawTextHelpFormatter
+from os import listdir
+
+
+def summarize(output_dir):
+    """
+    Load the json files contained in the output_dir and summarize the results
+    in a summary.json file saved to the output_dir
+    """
+
+    from os.path import isfile, join
+    json_filenames = [f for f in listdir(output_dir) if
+                      isfile(join(output_dir, f)) and
+                      f.endswith('.json') and
+                      f != 'summary.json']
+    print('Summarizing [%d] files in [%s]' % (len(json_filenames), output_dir))
+
+    summary = {
+        'success_count': 0,
+        'fail_count': 0,
+        'failed_scenarios': [],
+        'scenarios': []
+    }
+    for filename in json_filenames:
+        filepath = output_dir + "/" + filename
+        print('  Summarizing [%s]' % filename)
+        json_file = open(filepath)
+        jroot = json.load(json_file)
+
+        result = {
+            'filename': filename,
+            'success': jroot['success']
+        }
+
+        if jroot['success']:
+            summary['success_count'] += 1
+        else:
+            summary['fail_count'] += 1
+            failed_criteria = []
+            for criteria in jroot['criteria']:
+                if criteria['success'] is False:
+                    failed_criteria.append(criteria['name'])
+            result['failed_criteria'] = failed_criteria
+            summary['failed_scenarios'].append(filename)
+
+        summary['scenarios'].append(result)
+
+    summary_file = open(output_dir + "/summary.json", 'w')
+    json.dump(summary, summary_file)
+    print("Summary:[%s]" % json.dumps(summary, indent=4))
+
+
+description = "Report Consolidator: Consolidates JSON reports produced by the Scenario Runner"
+
+parser = argparse.ArgumentParser(description=description,
+                                 formatter_class=RawTextHelpFormatter)
+parser.add_argument('--outputDir', default='', help='Directory for output files (default: this directory)')
+args = parser.parse_args()
+
+summarize(args.outputDir)


### PR DESCRIPTION
@dsche I had a couple tasks associated with scenario runner reporting:
1. Create a machine-readable report, preferably json. Your modification did this for me, thank you.
2. Create a machine-readable summary of all the reports generated. I did that this morning using your json report. The output is contained in this PR.

Once your PR is merged I figure I'll do a refresh, but I wanted to let you know about this before then in case you're working on something similar.

The summary from 4 scenarios with 1 failure looks like this:
{
    "success_count": 3,
    "fail_count": 1,
    "failed_scenarios": [
        "FollowLeadingVehicle_22020-10-07-08-45-54.json"
    ],
    "scenarios": [
        {
            "filename": "FollowLeadingVehicle_12020-10-07-08-45-19.json",
            "success": true
        },
        {
            "filename": "FollowLeadingVehicle_22020-10-07-08-45-54.json",
            "success": false,
            "failed_criteria": [
                "CollisionTest"
            ]
        },
        {
            "filename": "FollowLeadingVehicle_42020-10-07-08-46-22.json",
            "success": true
        },
        {
            "filename": "FollowLeadingVehicle_32020-10-07-08-46-17.json",
            "success": true
        }
    ]
}

